### PR TITLE
Minor changes in blacklisting nouveau

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ These particular notes were originally worked out from an installation to an HP 
 		```# chmod +x NVIDIA-Linux-x86_64-440.44.run```
 	1. Blacklist the nouveau module:
 		
-		Create a file at `/usr/lib/modprobe.d/blacklist-nouveau.conf` with the following contents:
+		Create a file at `/etc/modprobe.d/blacklist-nouveau.conf` with the following contents:
 		```
 		blacklist nouveau
 		options nouveau modeset=0

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ These particular notes were originally worked out from an installation to an HP 
 		```# chmod +x NVIDIA-Linux-x86_64-440.44.run```
 	1. Blacklist the nouveau module:
 		
-		Create a file at /usr/lib/modprobe.d/blacklist-nouveau.conf with the following contents:
+		Create a file at `/usr/lib/modprobe.d/blacklist-nouveau.conf` with the following contents:
 		```
 		blacklist nouveau
 		options nouveau modeset=0

--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ These particular notes were originally worked out from an installation to an HP 
 		```# chmod +x NVIDIA-Linux-x86_64-440.44.run```
 	1. Blacklist the nouveau module:
 		
-		```# echo 'blacklist nouveau' >> /etc/modprobe.d/blacklist.conf```
+		Create a file at /usr/lib/modprobe.d/blacklist-nouveau.conf with the following contents:
+		```
+		blacklist nouveau
+		options nouveau modeset=0
+		```
 	1. Install dependencies:
 		
 		```


### PR DESCRIPTION
I had some problems earlier with the the original steps -even in other projects-, what solved my problem was using `options nouveau modeset=0`

This is disabling only the nouveau driver while for example nomodset disables more modules.
Going this way I was able to install drivers on several other distributions as well. 

I know this is a centos setup, but this might help someone someday. :)

