### PR TITLE
adding `# dracut --force` to blacklist nouveau

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ These particular notes were originally worked out from an installation to an HP 
 	1. Blacklist the nouveau module:
 		
 		```# echo 'blacklist nouveau' >> /etc/modprobe.d/blacklist.conf```
+	1. Regenerate the kernel initramfs:
+	
+		```# dracut --force```
 	1. Install dependencies:
 		
 		```


### PR DESCRIPTION
Adding the additional `dracut --force` step from p. 19 in the official NVIDIA documentation: https://docs.nvidia.com/pdf/CUDA_Installation_Guide_Linux.pdf