### PR TITLE
Clarifying broken grub

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,31 @@ These particular notes were originally worked out from an installation to an HP 
 	1. If the test is successful, change your default `systemd` target back so that you boot straight to the GUI:
 		
 		```# systemctl set-default graphical.target```
+		
+		1. Confirm that you're running the NVIDIA driver at any time by running `$ nvidia-smi`
+		
+1. At this point, the `grub` configuration will be "broken." If you were to reboot and to try to log into the GUI, the screen would just go completely black. To properly get into the GUI, you'll have to edit the `grub` configuration file temporarily, but this will only get you into the GUI once. To configure the `grub` configuration permanently, we'll have to modify and rebuilt the the `grub` configuration.
+	1.Reboot, and when the `grub` menu pops up, hit the `e` key.
+	1. On the `GRUB_CMDLINE_LINUX` line, remove `rhgb` and add `rd.driver.blacklist=nouveau"` so that the whole line is:
+		```GRUB_CMDLINE_LINUX="crashkernel=auto resume=/dev/mapper/cl-swap rd.lvm.lv=cl/root rd.lvm.lv=cl/swap quiet rd.driver.blacklist=nouveau"```
+	1. Hit `Ctrl-X` to boot.
+	1. Log into GNOME.
+	1. Become the superuser:
+		
+		```$ su -```
+	1. Use `vim` or your text editor of choice to open `/etc/default/grub`.
+	1. Just as before when you edited the `grub` configuration _temporarily,_ now edit this file permanently. For the `GRUB_CMDLINE_LINUX` line, remove `rhgb` and add `rd.driver.blacklist=nouveau"`, so that the whole line is:
+		```GRUB_CMDLINE_LINUX="crashkernel=auto resume=/dev/mapper/cl-swap rd.lvm.lv=cl/root rd.lvm.lv=cl/swap quiet rd.driver.blacklist=nouveau"```
+	1. Save and close the file. [If using `vim`, write and close: `:wq`]
+	
+	1. Rebuild the grub configuration again:
+	
+		```# grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg```
 	1. Reboot:
 		
 		```# reboot```
-	1. Confirm that you're running the NVIDIA driver at any time by running `$ nvidia-smi`
+	1. Your `grub` configuration should now be properly configured, so after rebooting, `grub` should automatically take you to the GNOME login screen, and then you'll be able to log into the GUI.
+	
 1. [OPTIONAL] Download and install the latest DeckLink driver
 	1. Download the latest driver [from the Blackmagic Design website](https://www.blackmagicdesign.com/support/family/capture-and-playback)
 	1. Become the `root` user:
@@ -123,20 +144,6 @@ These particular notes were originally worked out from an installation to an HP 
 		```# BlackmagicFirmwareUpdater update 0```
 	1.  If a firmware update was applied, reboot the machine after it completes. If no firmware update was required, a reboot is not necessary.
 
-1. At this point, installing Desktop Video to DKMS might have "broken" the `grub` configuration again. If you try to log into the GUI, the screen will just go black. So we'll need to go rebuild the `grub` configuration again.
-	1. If you can get to a virtual console, log in. Otherwise, SSH into the `root` account from a different machine on the network.
-		1. `vim` into `/etc/default/grub`
-		1. For the `GRUB_CMDLINE_LINUX` line, remove `rhgb` and add `rd.driver.blacklist=nouveau"`, so that the whole line is:
-		
-			```GRUB_CMDLINE_LINUX="crashkernel=auto resume=/dev/mapper/cl-swap rd.lvm.lv=cl/root rd.lvm.lv=cl/swap quiet rd.driver.blacklist=nouveau"```
-		1. Write and close: `:wq`
-		1. Rebuild the grub configuration again:
-	
-			```# grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg```
-		1. Reboot:
-	
-			```# reboot```
-	1. Alternatively, you can just edit the `grub` configuration temporarily by hitting `e` when the `grub` menu pops up, removing `rhgb`, adding in `rd.driver.blacklist=nouveau`, and hitting `Ctrl-X` to boot, but this is only temporary for the one boot. To _permanently_ blacklist the `nouveau` driver, you'll have to rebuild the `grub` configuration by following the steps above.
 1. Now we should be totally ready for DaVinci Resolve.
 	1. N.B. If you didn't already install `mesa-libGLU` for Media Express, Resolve definitely needs it, so make sure to install it:
 		

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ These particular notes were originally worked out from an installation to an HP 
 		
 1. At this point, the `grub` configuration will be "broken." If you were to reboot and to try to log into the GUI, the screen would just go completely black. To properly get into the GUI, you'll have to edit the `grub` configuration file temporarily, but this will only get you into the GUI once. To configure the `grub` configuration permanently, we'll have to modify and rebuild the the `grub` configuration.
 	1. Reboot, and when the `grub` menu pops up, hit the `e` key.
-	1. On the `GRUB_CMDLINE_LINUX` line, remove `rhgb` and add `rd.driver.blacklist=nouveau"` so that the whole line is:
+	1. On the `GRUB_CMDLINE_LINUX` line, remove `rhgb` and add `rd.driver.blacklist=nouveau` inside the quotation marks, so that the whole line is:
 		```GRUB_CMDLINE_LINUX="crashkernel=auto resume=/dev/mapper/cl-swap rd.lvm.lv=cl/root rd.lvm.lv=cl/swap quiet rd.driver.blacklist=nouveau"```
 	1. Hit `Ctrl-X` to boot.
 	1. Log into GNOME.
@@ -98,7 +98,7 @@ These particular notes were originally worked out from an installation to an HP 
 		
 		```$ su -```
 	1. Use `vim` or your text editor of choice to open `/etc/default/grub`.
-	1. Just as before when you edited the `grub` configuration _temporarily,_ now edit this file permanently. For the `GRUB_CMDLINE_LINUX` line, remove `rhgb` and add `rd.driver.blacklist=nouveau"`, so that the whole line is:
+	1. Just as before when you edited the `grub` configuration _temporarily,_ now edit this file permanently. For the `GRUB_CMDLINE_LINUX` line, remove `rhgb` and add `rd.driver.blacklist=nouveau` inside the quotation marks, so that the whole line is:
 		```GRUB_CMDLINE_LINUX="crashkernel=auto resume=/dev/mapper/cl-swap rd.lvm.lv=cl/root rd.lvm.lv=cl/swap quiet rd.driver.blacklist=nouveau"```
 	1. Save and close the file. [If using `vim`, write and close: `:wq`]
 	
@@ -131,7 +131,7 @@ These particular notes were originally worked out from an installation to an HP 
 		1. ```# rpm -ivh mediaexpress-<version>.x86_64.rpm```
 			1. The installer might fail and tell you that you `mediaexpress` needs `libGLU.so.1`, so install `libGLU` and try again:
 			
-			```# dnf install mesa-libGLU```
+				```# dnf install mesa-libGLU```
 	1. After the installation completes, you should see the terminal prompt. Reboot.
 	1. After the machine has rebooted, open a Terminal shell again
 	1. Become the `root` user again:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ These particular notes were originally worked out from an installation to an HP 
 		
 		1. Confirm that you're running the NVIDIA driver at any time by running `$ nvidia-smi`
 		
-1. At this point, the `grub` configuration will be "broken." If you were to reboot and to try to log into the GUI, the screen would just go completely black. To properly get into the GUI, you'll have to edit the `grub` configuration file temporarily, but this will only get you into the GUI once. To configure the `grub` configuration permanently, we'll have to modify and rebuilt the the `grub` configuration.
+1. At this point, the `grub` configuration will be "broken." If you were to reboot and to try to log into the GUI, the screen would just go completely black. To properly get into the GUI, you'll have to edit the `grub` configuration file temporarily, but this will only get you into the GUI once. To configure the `grub` configuration permanently, we'll have to modify and rebuild the the `grub` configuration.
 	1. Reboot, and when the `grub` menu pops up, hit the `e` key.
 	1. On the `GRUB_CMDLINE_LINUX` line, remove `rhgb` and add `rd.driver.blacklist=nouveau"` so that the whole line is:
 		```GRUB_CMDLINE_LINUX="crashkernel=auto resume=/dev/mapper/cl-swap rd.lvm.lv=cl/root rd.lvm.lv=cl/swap quiet rd.driver.blacklist=nouveau"```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ These particular notes were originally worked out from an installation to an HP 
 		1. Confirm that you're running the NVIDIA driver at any time by running `$ nvidia-smi`
 		
 1. At this point, the `grub` configuration will be "broken." If you were to reboot and to try to log into the GUI, the screen would just go completely black. To properly get into the GUI, you'll have to edit the `grub` configuration file temporarily, but this will only get you into the GUI once. To configure the `grub` configuration permanently, we'll have to modify and rebuilt the the `grub` configuration.
-	1.Reboot, and when the `grub` menu pops up, hit the `e` key.
+	1. Reboot, and when the `grub` menu pops up, hit the `e` key.
 	1. On the `GRUB_CMDLINE_LINUX` line, remove `rhgb` and add `rd.driver.blacklist=nouveau"` so that the whole line is:
 		```GRUB_CMDLINE_LINUX="crashkernel=auto resume=/dev/mapper/cl-swap rd.lvm.lv=cl/root rd.lvm.lv=cl/swap quiet rd.driver.blacklist=nouveau"```
 	1. Hit `Ctrl-X` to boot.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ These particular notes were originally worked out from an installation to an HP 
 	$ sudo dnf update --refresh
 	$ sudo reboot
 	```	
-1. Take note of the IP address on the LAN, because you might need to SSH into the machine later.
 1. Install the [kernel source](https://wiki.centos.org/HowTos/I_need_the_Kernel_Source):
 	
 	```$ sudo dnf install "kernel-devel-uname-r == $(uname -r)"```


### PR DESCRIPTION
Revised and reworded a bunch of the steps so that fixing and rebuilding the `grub` configuration is more straightforward. Got rid of the obsolete references to having to `ssh` into the box.